### PR TITLE
fix coinbase maturity as 1 for testnet as in komodo

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -374,6 +374,7 @@ impl Arbitrary for Block {
 /// Skip checking transparent coinbase spends in [`Block::partial_chain_strategy`].
 #[allow(clippy::result_unit_err)]
 pub fn allow_all_transparent_coinbase_spends(
+    _: Network,
     _: transparent::OutPoint,
     _: transparent::CoinbaseSpendRestriction,
     _: transparent::OrderedUtxo,
@@ -401,6 +402,7 @@ impl Block {
     ) -> BoxedStrategy<SummaryDebug<Vec<Arc<Self>>>>
     where
         F: Fn(
+                Network,
                 transparent::OutPoint,
                 transparent::CoinbaseSpendRestriction,
                 transparent::OrderedUtxo,
@@ -578,6 +580,7 @@ pub fn fix_generated_transaction<F, T, E>(
 ) -> Option<Transaction>
 where
     F: Fn(
+            Network,
             transparent::OutPoint,
             transparent::CoinbaseSpendRestriction,
             transparent::OrderedUtxo,
@@ -596,6 +599,7 @@ where
             // the transparent chain value pool is the sum of unspent UTXOs,
             // so we don't need to check it separately, because we only spend unspent UTXOs
             if let Some(selected_outpoint) = find_valid_utxo_for_spend(
+                network,
                 &mut transaction,
                 &mut spend_restriction,
                 height,
@@ -651,6 +655,7 @@ where
 ///
 /// If there is no valid output, or many search attempts have failed, returns `None`.
 pub fn find_valid_utxo_for_spend<F, T, E>(
+    network: Network,
     transaction: &mut Transaction,
     spend_restriction: &mut CoinbaseSpendRestriction,
     spend_height: Height,
@@ -659,6 +664,7 @@ pub fn find_valid_utxo_for_spend<F, T, E>(
 ) -> Option<transparent::OutPoint>
 where
     F: Fn(
+            Network,
             transparent::OutPoint,
             transparent::CoinbaseSpendRestriction,
             transparent::OrderedUtxo,
@@ -682,6 +688,7 @@ where
 
         // try the utxo as-is, then try it with deleted transparent outputs
         if check_transparent_coinbase_spend(
+            network,
             *candidate_outpoint,
             *spend_restriction,
             candidate_utxo.clone(),
@@ -691,6 +698,7 @@ where
             return Some(*candidate_outpoint);
         } else if has_shielded_outputs
             && check_transparent_coinbase_spend(
+                network,
                 *candidate_outpoint,
                 delete_transparent_outputs,
                 candidate_utxo.clone(),

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -47,6 +47,10 @@ use std::{collections::HashMap, fmt, iter};
 /// [7.1](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus)
 pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 
+/// Komodo testnet coinbase maturity
+pub const KOMODO_MIN_TESTNET_TRANSPARENT_COINBASE_MATURITY: u32 = 1;
+
+
 /// Arbitrary data inserted by miners into a coinbase transaction.
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Serialize))]

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -1,6 +1,7 @@
 //! Definitions of constants.
 
 pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
+pub use zebra_chain::transparent::KOMODO_MIN_TESTNET_TRANSPARENT_COINBASE_MATURITY;
 
 /// The maximum chain reorganisation height.
 ///

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -51,7 +51,7 @@ fn accept_shielded_mature_coinbase_utxo_spend() {
     };
 
     let result =
-        check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo.clone());
+        check::utxo::transparent_coinbase_spend(Network::Mainnet, outpoint, spend_restriction, ordered_utxo.clone());
     assert_eq!(result, Ok(ordered_utxo));
 }
 
@@ -76,7 +76,7 @@ fn accept_unshielded_mature_coinbase_utxo_spend() {
     let spend_restriction =
         transparent::CoinbaseSpendRestriction::OnlyShieldedOutputs { spend_height };
 
-    let result = check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo.clone());
+    let result = check::utxo::transparent_coinbase_spend(Network::Mainnet, outpoint, spend_restriction, ordered_utxo.clone());
     assert_eq!(
         result,
         Ok(ordered_utxo)
@@ -102,7 +102,7 @@ fn reject_immature_unshielded_coinbase_utxo_spend() {
     let spend_height = Height(min_spend_height.0 - 1);
     let spend_restriction = transparent::CoinbaseSpendRestriction::SomeTransparentOutputs { spend_height };
 
-    let result = check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo);
+    let result = check::utxo::transparent_coinbase_spend(Network::Mainnet, outpoint, spend_restriction, ordered_utxo);
     assert_eq!(result, Err(ImmatureTransparentCoinbaseSpend {
         outpoint,
         spend_height,
@@ -133,7 +133,7 @@ fn reject_immature_coinbase_utxo_spend() {
     let spend_restriction =
         transparent::CoinbaseSpendRestriction::OnlyShieldedOutputs { spend_height };
 
-    let result = check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo);
+    let result = check::utxo::transparent_coinbase_spend(Network::Mainnet, outpoint, spend_restriction, ordered_utxo);
     assert_eq!(
         result,
         Err(ImmatureTransparentCoinbaseSpend {


### PR DESCRIPTION
required for zebra-state notarisation tests to work (which use test blocks with CB maturity 1) see #39