### PR TITLE
Patch komodo checkpoint fix check fork

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -485,31 +485,6 @@ impl StateService {
     ) -> Result<(), ValidateContextError> {
         let relevant_chain = self.any_ancestor_blocks(prepared.block.header.previous_block_hash);
 
-        // komodo_checkpoint check before other checks
-        if let Some(last_nota) = &self.mem.last_nota {
-            tracing::debug!("prepared.height={:?}, last_nota_height={:?}, last_nota_block_hash={:?}", prepared.height, last_nota.notarised_height, last_nota.block_hash);
-            // verify that the block info returned from komodo_notarizeddata matches the actual block
-            if let Some(last_nota_ht) = self.best_height_by_hash(last_nota.block_hash) {
-                if last_nota_ht == last_nota.notarised_height { // if notarized_hash not in chain, reorg
-                    if prepared.height < last_nota.notarised_height {
-                        // forked chain %d older than last notarized (height %d) vs %d" case
-                        return Err(ValidateContextError::InvalidNotarisedChain(
-                            prepared.hash,
-                            prepared.height,
-                            last_nota.notarised_height
-                        ));
-                    } else if prepared.height == last_nota.notarised_height && prepared.hash != last_nota.block_hash {
-                        // [%s] nHeight.%d == NOTARIZED_HEIGHT.%d, diff hash case
-                        return Err(ValidateContextError::InvalidNotarisedChain(
-                            prepared.hash,
-                            prepared.height,
-                            last_nota.notarised_height
-                        ));
-                    }
-                }
-            }
-        }
-
         // Security: check proof of work before any other checks
         check::block_is_valid_for_recent_chain(
             prepared,
@@ -641,8 +616,8 @@ impl StateService {
                         trace!("komodo last nota height={:?} spent_outputs.len={}", height, spent_outputs.len());
 
                         if let Some(nota) = komodo_block_has_notarisation_tx(self.network, &block, &spent_outputs, &height) {
-                            self.mem.last_nota = Some(nota);
-                            info!("komodo found last nota at height {:?}", height);
+                            self.mem.last_nota = Some(nota.clone());
+                            info!("komodo found last nota at height {:?}, last notarized height={:?}", height, nota.notarised_height);
                             break;
                         }
                     } else {

--- a/zebra-state/src/service/check/tests/komodo_nn.rs
+++ b/zebra-state/src/service/check/tests/komodo_nn.rs
@@ -17,7 +17,7 @@ use crate::{ValidateContextError, FinalizedBlock};
 use crate::arbitrary::Prepare;
 
 const CHAIN_A_BLOCK_HASH_WITH_NOTA: &str = "00e5a0b985d58cd3be4c6b580f30de57d041a56589d61e98b85a0fe20f76383f";
-const CHAIN_A_BLOCK_HASH_TO_FAIL: &str = "00065fd6734d951e25db612fb6ec4a93567b5545f218de24142f075fd12eee1c";
+const CHAIN_A_BLOCK_HASH_TO_FAIL: &str = "009b7faa4fffb879db787dec6acafe02767297158a867361ad82a699c6c8839c";
 const NON_NOTARY_P2PK: &str = "2102c50c23b6578f6a688f9868efca41bddd33b4225583474bb6183ff3ddf593ae01ac";
 
 struct SampleChain<'a> {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 
+use chrono::{DateTime, Utc};
 use zebra_chain::{
     block::{self, Block},
     history_tree::HistoryTree,
@@ -161,10 +162,6 @@ impl NonFinalizedState {
         // and drop the cloned parent Arc, or newly created chain fork.
         let modified_chain = self.validate_and_commit(parent_chain, prepared, finalized_state)?;
 
-        // Check if the new chain has more power and is not forked below the last notarized height.
-        // Note that at this stage if a nota exists in the current block it is stored as the 'latest nota'
-        self.komodo_check_fork_is_valid(&modified_chain)?;
-
         // If the block is valid:
         // - add the new chain fork or updated chain to the set of recent chains
         // - remove the parent chain, if it was in the chain set
@@ -199,10 +196,6 @@ impl NonFinalizedState {
         // If the block is invalid, return the error, and drop the newly created chain fork
         let chain = self.validate_and_commit(Arc::new(chain), prepared, finalized_state)?;
 
-        // Check if the new chain has more power and is not forked below the last notarized height.
-        // Note that at this stage if a nota exists in the current block it is stored as the 'latest nota'
-        self.komodo_check_fork_is_valid(&chain)?;
-
         // If the block is valid, add the new chain fork to the set of recent chains.
         self.chain_set.insert(chain);
         self.update_metrics_for_committed_block(height, hash);
@@ -212,6 +205,7 @@ impl NonFinalizedState {
 
     /// Contextually validate `prepared` using `finalized_state`.
     /// If validation succeeds, push `prepared` onto `new_chain`.
+    /// komodo: also updates the latest nota
     ///
     /// `new_chain` should start as a clone of the parent chain fork,
     /// or the finalized tip.
@@ -226,25 +220,7 @@ impl NonFinalizedState {
         //
 
         // komodo: get chain tip last block time to calc interest
-        let last_block_time = {
-            if prepared.height > block::Height(0)  {
-                if let Some(tip) = new_chain.tip_block() { 
-                    Some(tip.block.header.time) 
-                } else { 
-                    // if new_chain is empty then get the finalized tip (in zebra any forks could exist only in the non-finalized part):
-                    if let Some(tip) = finalized_state.tip_block()  {
-                        Some(tip.header.time)
-                    }
-                    else {
-                        // let's not panic here because several unit tests create a state started from arbitrary height
-                        info!("komodo could not get chain tip for block={:?}", prepared.height); 
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        };
+        let last_block_time = Self::komodo_get_last_block_time(finalized_state, new_chain.clone(), &prepared);
 
         // TODO: if these disk reads show up in profiles, run them in parallel, using std::thread::spawn()
         let spent_utxos = check::utxo::transparent_spend(
@@ -285,9 +261,16 @@ impl NonFinalizedState {
         })?;
 
         let spent_outputs = outputs_from_utxos(utxos_from_ordered_utxos(spent_utxos));
-        self.komodo_find_block_nota_and_update_last(&prepared.block, &spent_outputs, &prepared.height);
 
-        Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates)
+        let result = Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates);
+
+        // komodo checks related to notarization:
+        if let Ok(new_chain) = result.as_ref()   {
+            self.komodo_checkpoint(&prepared)?;     // prevent new blocks to be added from below last notarised height
+            self.komodo_check_fork_is_valid(new_chain)?;    // prevent existing branches without nota to grow 
+            self.komodo_find_block_nota_and_update_last(&prepared.block, &spent_outputs, &prepared.height); // try to find nota in the new block and set it as the latest nota
+        }
+        result
     }
 
     /// Validate `contextual` and update `new_chain`, doing CPU-intensive work in parallel batches.
@@ -559,12 +542,12 @@ impl NonFinalizedState {
         match (komodo_block_has_notarisation_tx(self.network, block, spent_outputs, height), self.last_nota.as_ref()) {
             (Some(found_nota), Some(last_nota)) => {
                 if last_nota.notarised_height < found_nota.notarised_height {
-                    debug!("komodo found update nota last notarised height={:?}", found_nota.notarised_height);
+                    debug!("komodo found update nota at height={:?}, last notarised height={:?}", height, found_nota.notarised_height);
                     self.last_nota = Some(found_nota);
                 }
             },
             (Some(found_nota), None) =>  {
-                debug!("komodo found new nota last notarised height={:?}", found_nota.notarised_height);
+                debug!("komodo found new nota at height={:?}, last notarised height={:?}", height, found_nota.notarised_height);
                 self.last_nota = Some(found_nota);
             },
             (None, _) => (),
@@ -576,89 +559,145 @@ impl NonFinalizedState {
     pub fn komodo_check_fork_is_valid(&self, chain_with_new_block: &Chain) -> Result<(), ValidateContextError> {
 
         if let Some(last_nota) = &self.last_nota {
-            trace!("komodo_check_fork_is_valid chain_new height={:?} hash={:?} last_nota.height={:?}", chain_with_new_block.non_finalized_tip_height(), chain_with_new_block.non_finalized_tip_hash(), last_nota.notarised_height);
+            debug!("komodo_check_fork_is_valid chain_new height={:?} hash={:?} last_nota.height={:?}", chain_with_new_block.non_finalized_tip_height(), chain_with_new_block.non_finalized_tip_hash(), last_nota.notarised_height);
             if let Some(best_chain) = self.best_chain() {
+                
+                if let Some(chain_with_nota) = self.chain_set.iter().rev().find(|chain| chain.height_by_hash.contains_key(&last_nota.block_hash))  {
 
-                trace!("komodo_check_fork_is_valid best_chain.tip={:?} hash={:?}", best_chain.non_finalized_tip_height(), best_chain.non_finalized_tip_hash());
-                // find the fork point
-                // I think it is important to start search from the tip (in rev order) 
-                // as the bottom part of the chain has many common blocks with the best_chain because both grow from the finalized tip
-                if let Some(fork) = chain_with_new_block.blocks.iter().rev().find(|pair| best_chain.height_by_hash.contains_key(&pair.1.hash) ) {
+                    trace!("komodo_check_fork_is_valid best_chain.tip={:?} hash={:?}", best_chain.non_finalized_tip_height(), best_chain.non_finalized_tip_hash());
+                    // find the fork point
+                    // I think it is important to start search from the tip (in rev order) 
+                    // as the bottom part of the chain has many common blocks with the best_chain because both grow from the finalized tip
+                    if let Some(fork) = chain_with_new_block.blocks.iter().rev().find(|pair| chain_with_nota.height_by_hash.contains_key(&pair.1.hash) ) {
 
-                    // truncate the new chain's bottom blocks below the fork point (and leave only block hashes in the top part):
-                    let block_hashes_truncated = chain_with_new_block.blocks.iter()
-                        .skip_while(|e| e.1 != fork.1)
-                        .map(|p| (p.0, p.1.hash))
-                        .collect::<Vec<_>>();
-                    trace!("komodo_check_fork_is_valid block_hashes_truncated={:?}", block_hashes_truncated);
-
-                    let new_has_nota = block_hashes_truncated.iter().find(|pair| pair.1 == last_nota.block_hash).is_some();
-                    
-                    /*
-                    // suggested new algo change:
-                    // if the new chain has the last nota but the best chain does not 
-                    // then mark the best chain as bad and allow the new block to add
-                    if new_has_nota {
-
-                        if best_chain.blocks.iter()
+                        // truncate the new chain's bottom blocks below the fork point (and leave only block hashes in the top part):
+                        let block_hashes_truncated = chain_with_new_block.blocks.iter()
                             .skip_while(|e| e.1 != fork.1)
-                            .skip(1)
-                            .find(|pair| pair.1.hash == last_nota.block_hash).is_some()    {
-                            info!("best chain does not contain nota, marking it as bad");
+                            .map(|p| (p.0, p.1.hash))
+                            .collect::<Vec<_>>();
+                        trace!("komodo_check_fork_is_valid block_hashes_truncated={:?}", block_hashes_truncated);
 
-                            let modified_chain = Arc::try_unwrap(new_chain)
-                                .unwrap_or_else(|shared_chain| (*shared_chain).clone());
-                            modified_chain.set_as_bad();  
-                            self.chain_set
-                                .retain(|chain| chain.non_finalized_tip_hash() != parent_hash);
-                            self.chain_set.insert(modified_chain);
-                            ...
-                            return Ok(());
+                        let new_has_nota = block_hashes_truncated.iter().find(|pair| pair.1 == last_nota.block_hash).is_some();
+                        
+                        /*
+                        // suggested new algo change:
+                        // if the new chain has the last nota but the best chain does not 
+                        // then mark the best chain as bad and allow the new block to add
+                        if new_has_nota {
+
+                            if best_chain.blocks.iter()
+                                .skip_while(|e| e.1 != fork.1)
+                                .skip(1)
+                                .find(|pair| pair.1.hash == last_nota.block_hash).is_some()    {
+                                info!("best chain does not contain nota, marking it as bad");
+
+                                let modified_chain = Arc::try_unwrap(new_chain)
+                                    .unwrap_or_else(|shared_chain| (*shared_chain).clone());
+                                modified_chain.set_as_bad();  
+                                self.chain_set
+                                    .retain(|chain| chain.non_finalized_tip_hash() != parent_hash);
+                                self.chain_set.insert(modified_chain);
+                                ...
+                                return Ok(());
+                            }
+                        }
+                        */
+
+
+                        debug!(
+                            chain_with_new_block_non_fin_height = chain_with_new_block.non_finalized_tip_height().0,
+                            best_chain_non_fin_height = best_chain.non_finalized_tip_height().0,
+                            new_chain_has_last_nota = chain_with_new_block.height_by_hash.contains_key(&last_nota.block_hash),
+                            blocks_truncated_has_last_nota = new_has_nota,
+                            best_chain_tip_height_over_notarised_height = best_chain.non_finalized_tip_height() > last_nota.notarised_height,
+                            is_fork_below_notarised_height = fork.0 < &last_nota.notarised_height,
+                            best_chain_root_height = best_chain.non_finalized_tip_height().0,
+                            fork_height = fork.0.0,
+                            last_notarised_height = last_nota.notarised_height.0,
+                            new_chain_has_more_power = chain_with_new_block > best_chain,
+                            "komodo checking notarised height for new chain:"
+                        );
+
+                        // The condition for forks below the last notarised height:
+                        // if chain_with_new_block has more work than best_chain (that is, a new best chain candidate)
+                        // and chain_with_new_block does not contain the last nota
+                        // and fork.height < last_nota.height
+                        // and best_chain.height > last_nota.height 
+                        // then do not allow this block and this fork:
+
+                        if chain_with_new_block > best_chain &&  // new chain has more work
+
+                            // There is no such check in ActivateBestChainStep() because there notas are processed only when the chain is activated,
+                            // so it is guaranteed that the known 'latest' nota is in the active chain.
+                            // In zebra we cannot do this and notas are processed in any added block 
+                            // and if the latest nota is in the new chain it should be considered as valid  
+                            !new_has_nota  && // no error if the new chain contains the last nota 
+
+                            best_chain.non_finalized_tip_height() > last_nota.notarised_height && // not sure why this condition is needed as assumed best chain could not be built without notas in it
+                            fork.0 < &last_nota.notarised_height {  
+                            return Err(ValidateContextError::KomodoInvalidNotarisedChain(chain_with_new_block.non_finalized_tip_hash(), chain_with_new_block.non_finalized_root().1, last_nota.notarised_height));
                         }
                     }
-                    */
-
-
-                    debug!(
-                        chain_with_new_block_non_fin_height = chain_with_new_block.non_finalized_tip_height().0,
-                        best_chain_non_fin_height = best_chain.non_finalized_tip_height().0,
-                        new_chain_has_last_nota = chain_with_new_block.height_by_hash.contains_key(&last_nota.block_hash),
-                        blocks_truncated_has_last_nota = new_has_nota,
-                        best_chain_tip_height_over_notarised_height = best_chain.non_finalized_tip_height() > last_nota.notarised_height,
-                        is_fork_below_notarised_height = fork.0 < &last_nota.notarised_height,
-                        best_chain_root_height = best_chain.non_finalized_tip_height().0,
-                        fork_height = fork.0.0,
-                        last_notarised_height = last_nota.notarised_height.0,
-                        new_chain_has_more_power = chain_with_new_block > best_chain,
-                        "komodo checking notarised height for new chain:"
-                    );
-
-                    // The condition for forks below the last notarised height:
-                    // if chain_with_new_block has more work than best_chain (that is, a new best chain candidate)
-                    // and chain_with_new_block does not contain the last nota
-                    // and fork.height < last_nota.height
-                    // and best_chain.height > last_nota.height 
-                    // then do not allow this block and this fork:
-
-                    if chain_with_new_block > best_chain &&  // new chain has more work
-
-                        // There is no such check in ActivateBestChainStep() because there notas are processed only when the chain is activated,
-                        // so it is guaranteed that the known 'latest' nota is in the active chain.
-                        // In zebra we cannot do this and notas are processed in any added block 
-                        // and if the latest nota turns out to be in the new chain it should be considered as valid  
-                        !chain_with_new_block.height_by_hash.contains_key(&last_nota.block_hash)  && // no error if the new chain contains the last nota 
-
-                        best_chain.non_finalized_tip_height() > last_nota.notarised_height && // not sure why this condition is needed as assumed best chain could not be built without notas in it
-                        fork.0 < &last_nota.notarised_height {  
-                        return Err(ValidateContextError::KomodoInvalidNotarisedChain(chain_with_new_block.non_finalized_tip_hash(), chain_with_new_block.non_finalized_root().1, last_nota.notarised_height));
+                    else {
+                        // this should not happen actually
+                        error!("komodo internal error: could not find fork point for chain {:?}", chain_with_new_block);
                     }
-                }
-                else {
-                    // this should not happen actually
-                    error!("komodo internal error: could not find fork point for chain {:?}", chain_with_new_block);
+                } else {
+                    debug!("komodo: last nota not found in non-finalized branches, assuming it is in finalized state");
                 }
             }
         }
         Ok(())
     }
+
+    /// komodo notarization checks: new block height must be >= the last notarised height
+    pub fn komodo_checkpoint(&self, prepared: &PreparedBlock) -> Result<(), ValidateContextError> {
+        if let Some(last_nota) = &self.last_nota {
+            tracing::debug!("komodo_checkpoint prepared.height={:?}, last_nota_height={:?}, last_nota_block_hash={:?}", prepared.height, last_nota.notarised_height, last_nota.block_hash);
+            // verify that the block info returned from komodo_notarizeddata matches the actual block
+            if let Some(last_nota_ht) = self.best_height_by_hash(last_nota.block_hash) {
+                if last_nota_ht == last_nota.notarised_height { // if notarized_hash not in chain, reorg
+                    if prepared.height < last_nota.notarised_height {
+                        // forked chain %d older than last notarized (height %d) vs %d" case
+                        return Err(ValidateContextError::KomodoInvalidNotarisedChain(
+                            prepared.hash,
+                            (prepared.height - 1).unwrap_or(block::Height(0)), // fork point is the latest common block
+                            last_nota.notarised_height
+                        ));
+                    } else if prepared.height == last_nota.notarised_height && prepared.hash != last_nota.block_hash {
+                        // [%s] nHeight.%d == NOTARIZED_HEIGHT.%d, diff hash case
+                        return Err(ValidateContextError::KomodoInvalidNotarisedChain(
+                            prepared.hash,
+                            (prepared.height - 1).unwrap_or(block::Height(0)),
+                            last_nota.notarised_height
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// komodo: get chain tip last block time to calc interest
+    fn komodo_get_last_block_time(finalized_state: &ZebraDb, chain: Arc<Chain>, prepared: &PreparedBlock) -> Option<DateTime<Utc>> {
+            
+        if prepared.height > block::Height(0)  {
+            if let Some(tip) = chain.tip_block() { 
+                Some(tip.block.header.time) 
+            } else { 
+                // if new_chain is empty then get the finalized tip (in zebra any forks could exist only in the non-finalized part):
+                if let Some(tip) = finalized_state.tip_block()  {
+                    Some(tip.header.time)
+                }
+                else {
+                    // let's not panic here because several unit tests create a state started from arbitrary height
+                    info!("komodo could not get chain tip for block={:?}", prepared.height); 
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
 }
+


### PR DESCRIPTION
Refactored komodo_checkpoint and komodo_get_last_block_time as dedicated function,
fixed komodo_check_fork_is_valid so finds a branch with nota not assuming nota always in the best chain

