### PR TITLE
refactor CheckProofOfWork rules: should fix issue #66

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -106,45 +106,16 @@ pub fn difficulty_is_valid(
     //
     // The difficulty filter is also context-free.
     if hash > &difficulty_threshold {
-        /* pow (non easy-diff) blocks with incorrect diff, considered as exceptions */
-        if height >= &Height(205641) && height <= &Height(791989) {     // TODO: add mainnet check
+
+        /* https://github.com/KomodoPlatform/komodo/blob/156dba60184c07d0781a57d5b5005b8f3dba0c98/src/pow.cpp#L757 */
+        if network == Network::Mainnet && height <= &Height(792_000) {
             return Ok(());
         }
 
-        /* check if it's valid easy-diff NN mining */
-        /* 
-        let cb_tx = block.transactions.get(0);
-        if cb_tx.is_some() {
-            if cb_tx.unwrap().outputs().len() > 0 {
-                let lock_script_raw = &cb_tx.unwrap().outputs()[0].lock_script.as_raw_bytes();
-                /*if lock_script_raw.len() == 35 && lock_script_raw[0] == 0x21 && lock_script_raw[34] == 0xac {
-                    let pk = &lock_script_raw[1..34];
-                    if let Ok(pk) = PublicKey::from_slice(pk) {
-                        if is_notary_node(height, &pk) {
-                            return Ok(());
-                        }
-                    }
-                }*/
-                if komodo_is_notary_node_output(height, &cb_tx.unwrap().outputs()[0]) {
-                    return Ok(());
-                }
-            }
-        }
-        */
-
-        if network == Network::Mainnet && height < &Height(250000) {
-            return Ok(())   // skip diff check for mainnet while hardcoded notaries. TODO: fix diff check for hardcoded notaries
-        }
-
-        
-        if height == &Height(0)  {  
-            return Ok(());   // skip genesis, TODO: fix genesis diff for testnet
-        }
-
-        // check if this is a notary block
+        // possible easy-diff (notary-mined) block, but a thorough check will be conducted during contextual validation.
         if let Some(pk) = komodo_get_block_pubkey(block) {
             if NN::komodo_is_notary_pubkey(network, &height, &pk) {
-                return Ok(()); // skip the next difficulty check rule  
+                return Ok(());
             }
         }
 

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -267,13 +267,12 @@ pub enum ValidateContextError {
     #[error("invalid difficulty threshold in komodo special block header {0:?} {1:?}")]
     KomodoSpecialBlockInvalidDifficulty(zebra_chain::block::Height, zebra_chain::block::Hash),
 
-    #[error("komodo special notary block {0:?} has a difficulty threshold {2:?} that is easier than the {3:?} difficulty limit {4:?}, hash: {1:?}")]
-    KomodoSpecialBlockTargetDifficultyLimit(
+    #[error("block {0:?} on {3:?} has a hash {1:?} that is easier than its difficulty threshold {2:?}")]
+    DifficultyFilter(
         zebra_chain::block::Height,
         zebra_chain::block::Hash,
         zebra_chain::work::difficulty::ExpandedDifficulty,
         zebra_chain::parameters::Network,
-        zebra_chain::work::difficulty::ExpandedDifficulty,
     ),
 
     #[error("komodo special notary block invalid")]

--- a/zebra-state/src/komodo_notaries.rs
+++ b/zebra-state/src/komodo_notaries.rs
@@ -109,6 +109,7 @@ fn is_second_block_allowed(notary_id: NotaryId, blocktime: DateTime<Utc>, thresh
     if v_priority_list.len() != 64 {
         return Err(NotaryValidateContextError::NotaryInternalError(String::from("invalid priority list")));
     }
+
     if blocktime >= threshold && delta > 0   {
         if let Ok(pos) = usize::try_from((blocktime - threshold).num_seconds() / delta as i64) {
             if pos < v_priority_list.len()  {
@@ -150,7 +151,6 @@ fn komodo_check_if_second_block_allowed<C>(network: Network, notary_id: NotaryId
         tracing::info!("komodo notary hf22 second block allowed for ht={:?}", height);
         return Ok(());
     }
-    error!("komodo invalid second block generated for notary_id={} block.header={:?}", notary_id, block.header);
     Err(NotaryValidateContextError::NotaryBlockInvalid(*height, block.hash(), String::from("invalid second block after gap")))
 }
 

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -108,7 +108,10 @@ where
 
     let f_is_special_notary_block = match komodo_is_special_notary_block(&prepared.block, &prepared.height, network, relevant_chain.into_iter()) {
         Ok(f_is_special) => f_is_special,
-        Err(_) => false, // returns error if special block invalid, i.e. it should be validate as regular block
+        Err(e) => { // returns error if special block invalid, i.e. it should be validate as regular block
+            tracing::debug!("block ht={:?}, komodo_is_special_notary_block error: ", e.to_string());
+            false
+        }
     };
 
     let bn_target = if f_is_special_notary_block

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -114,7 +114,7 @@ where
         tracing::debug!("block ht={:?} is a komodo special block", prepared.height);
 
         // check min difficulty for a special block:
-        if difficulty_threshold_exp > ExpandedDifficulty::target_difficulty_limit(network) {
+        if hash > ExpandedDifficulty::target_difficulty_limit(network) {
             return Err(ValidateContextError::KomodoSpecialBlockTargetDifficultyLimit(
                 prepared.height,
                 prepared.hash,

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -106,7 +106,12 @@ where
         difficulty_adjustment,
     )?;
 
-    let bn_target = if komodo_is_special_notary_block(&prepared.block, &prepared.height, network, relevant_chain.into_iter())? // returns error if special block invalid
+    let f_is_special_notary_block = match komodo_is_special_notary_block(&prepared.block, &prepared.height, network, relevant_chain.into_iter()) {
+        Ok(f_is_special) => f_is_special,
+        Err(_) => false, // returns error if special block invalid, i.e. it should be validate as regular block
+    };
+
+    let bn_target = if f_is_special_notary_block
     {
         tracing::debug!("block ht={:?} is a komodo special block", prepared.height);
         ExpandedDifficulty::target_difficulty_limit(network)

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -120,8 +120,6 @@ where
         prepared.block.header.difficulty_threshold.to_expanded().ok_or(ValidateContextError::KomodoSpecialBlockInvalidDifficulty(prepared.height, prepared.hash))?
     };
 
-    assert!(!prepared.hash.0.iter().all(|&x| x == 0), "hash must not be all zeroes"); // TODO: check for debug purposes, if hash in prepared initialised correctly
-
     // check proof of work matches claimed amount
     if prepared.hash > bn_target {
         /* https://github.com/KomodoPlatform/komodo/blob/156dba60184c07d0781a57d5b5005b8f3dba0c98/src/pow.cpp#L757 */

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -5,11 +5,11 @@ use std::{borrow::Borrow, sync::Arc, time::SystemTime};
 use chrono::{Duration, DateTime, Utc};
 
 use zebra_chain::{
-    block::{self, Block, ChainHistoryBlockTxAuthCommitmentHash, CommitmentError},
+    block::{self, Block, ChainHistoryBlockTxAuthCommitmentHash, CommitmentError, Height},
     history_tree::HistoryTree,
     parameters::POW_AVERAGING_WINDOW,
     parameters::{Network, NetworkUpgrade},
-    work::difficulty::CompactDifficulty, transparent, amount::{Amount, NonNegative}, transaction::{LockTime, Transaction}, interest::KOMODO_MAXMEMPOOLTIME,
+    work::difficulty::{CompactDifficulty, ExpandedDifficulty}, transparent, amount::{Amount, NonNegative}, transaction::{LockTime, Transaction}, interest::KOMODO_MAXMEMPOOLTIME,
 };
 
 use crate::{constants, BoxError, PreparedBlock, ValidateContextError};
@@ -100,33 +100,29 @@ where
     
     let difficulty_adjustment =
         AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
+
     check::difficulty_threshold_is_valid(
         prepared.block.header.difficulty_threshold,
         difficulty_adjustment,
     )?;
 
-    let difficulty_threshold_exp = prepared.block.header.difficulty_threshold.to_expanded().ok_or(ValidateContextError::KomodoSpecialBlockInvalidDifficulty(prepared.height, prepared.hash))?;
-    let hash = prepared.block.hash();
-
-    // check komodo contextual rules for special notary blocks:
-    if hash > difficulty_threshold_exp && komodo_is_special_notary_block(&prepared.block, &prepared.height, network, relevant_chain.into_iter())? {  // returns error if special block invalid
-        use zebra_chain::work::difficulty::ExpandedDifficulty;
+    let bn_target = if komodo_is_special_notary_block(&prepared.block, &prepared.height, network, relevant_chain.into_iter())? // returns error if special block invalid
+    {
         tracing::debug!("block ht={:?} is a komodo special block", prepared.height);
-
-        // check min difficulty for a special block:
-        if hash > ExpandedDifficulty::target_difficulty_limit(network) {
-            return Err(ValidateContextError::KomodoSpecialBlockTargetDifficultyLimit(
-                prepared.height,
-                prepared.hash,
-                difficulty_threshold_exp,
-                network,
-                ExpandedDifficulty::target_difficulty_limit(network),
-            ))?;
-        }
-    }
-    else {
-        // ordinary block, nothing to check, all checks must have completed 
+        ExpandedDifficulty::target_difficulty_limit(network)
+    } else {
         tracing::debug!("block ht={:?} is an ordinary komodo block", prepared.height);
+        prepared.block.header.difficulty_threshold.to_expanded().ok_or(ValidateContextError::KomodoSpecialBlockInvalidDifficulty(prepared.height, prepared.hash))?
+    };
+
+    assert!(!prepared.hash.0.iter().all(|&x| x == 0), "hash must not be all zeroes"); // TODO: check for debug purposes, if hash in prepared initialised correctly
+
+    // check proof of work matches claimed amount
+    if prepared.hash > bn_target {
+        /* https://github.com/KomodoPlatform/komodo/blob/156dba60184c07d0781a57d5b5005b8f3dba0c98/src/pow.cpp#L757 */
+        if network == Network::Mainnet && prepared.height > Height(792_000) {
+            return Err(ValidateContextError::DifficultyFilter(prepared.height, prepared.hash, bn_target, network));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This pull request includes refactoring of the `difficulty_is_valid` and `block_is_valid_for_recent_chain` functions to make the conditions more similar to what we have in `CheckProofOfWork`, which will make them easier to understand. Additionally, it should address the chain sync issue mentioned in this link: https://github.com/KomodoPlatform/zebra/issues/66.